### PR TITLE
Factory bot compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://rubygems.services.local.ch'
 
 # Specify your gem's dependencies in factory_json.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FactoryJson
 
 Hi! The main purpose of this gem is to provide a simple way to create JSON data structures using the power of
-FactoryGirl's DSL.
+FactoryBot's DSL.
 
 ## Installation
 
@@ -19,7 +19,7 @@ Or install it yourself as:
 
 ## Usage
 
-This extension provides two new ways of working with FactoryGirl
+This extension provides two new ways of working with FactoryBot
 
 #### Dealing with Hashes
 
@@ -27,13 +27,13 @@ Tired of creating json fixtures somewhere in your app and keeping them up to dat
 
 ```ruby
 # spec/factories/data_structures.rb
-FactoryGirl.define do
+FactoryBot.define do
   factory :entry, class: Hash do
     name "This one is special"
     location "The place where you can always see a Sunrise"
 
     after(:build) do |entry|
-      entry[:relations] = FactoryGirl.build_list(entry_relation, 3, :with_address)
+      entry[:relations] = FactoryBot.build_list(entry_relation, 3, :with_address)
     end
   end
 
@@ -53,8 +53,8 @@ end
 And this might be a way to use these in our specs
 
 ```ruby
-entry_relation = FactoryGirl.as_json(:entry_relation, :with_address) # to return data as a Ruby hash, that beeing piped through JSON parse
-entry_relation = FactoryGirl.json(:entry_relation, :with_address) # to return string, that contains valid JSON
+entry_relation = FactoryBot.as_json(:entry_relation, :with_address) # to return data as a Ruby hash, that beeing piped through JSON parse
+entry_relation = FactoryBot.json(:entry_relation, :with_address) # to return string, that contains valid JSON
 ```
 
 #### Dealing with Models
@@ -100,7 +100,7 @@ class Profile
 end
 
 # spec/factories.rb
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     name "User 1"
     email "test@example.com"
@@ -120,10 +120,10 @@ end
 
 
 ```ruby
-user = FactoryGirl.build(:user, :with_profile) # to return new User object
-user = FactoryGirl.create(:user, :with_profile) # to return persistent User object
-user_hash = FactoryGirl.as_json(:user, :with_profile) # to return data as a Ruby hash, that beeing piped through JSON parse
-user_json = FactoryGirl.json(:user, :with_profile) # to return string, that contains valid JSON
+user = FactoryBot.build(:user, :with_profile) # to return new User object
+user = FactoryBot.create(:user, :with_profile) # to return persistent User object
+user_hash = FactoryBot.as_json(:user, :with_profile) # to return data as a Ruby hash, that beeing piped through JSON parse
+user_json = FactoryBot.json(:user, :with_profile) # to return string, that contains valid JSON
 ```
 
 ## Testing
@@ -134,7 +134,7 @@ Testing is pretty much standard
 rspec spec
 ```
 
-Testing compatibility with FactoryGirl
+Testing compatibility with FactoryBot
 
 ```bash
 rspec `bundle show factory_girl`/spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,10 @@
 require "bundler/gem_tasks"
 
+ENV['gem_push'] = 'false' # Utilizes feature in bundler 1.3.0
+# Let bundler's release task do its job, minus the push to Rubygems,
+# and after it completes, use "gem inabox" to publish the gem to our
+# internal gem server.
+Rake::Task['release'].enhance do
+  spec = Gem::Specification.load(Dir.glob("*.gemspec").first)
+  sh "gem inabox pkg/#{spec.name}-#{spec.version}.gem"
+end

--- a/factory_json.gemspec
+++ b/factory_json.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = FactoryJson::VERSION
   spec.authors       = ["E-Max"]
   spec.email         = ["max.zab87@gmail.com"]
-  spec.summary       = %q{FactoryGirl's extension for JSON support.}
-  spec.description   = %q{FactoryGirl can now handle JSON representation for an object.}
+  spec.summary       = %q{FactoryBot's extension for JSON support.}
+  spec.description   = %q{FactoryBot can now handle JSON representation for an object.}
   spec.homepage      = "https://github.com/local-ch/factory_json"
   spec.license       = "MIT"
 
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_dependency "factory_girl"
+  spec.add_dependency "factory_bot"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bundler", "~> 1.6"
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activerecord", ">= 3.0.0"
 
   # Compatibility test
-  spec.add_development_dependency "factory_girl_rails"
+  spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "ciderizer"
 end

--- a/factory_json.gemspec
+++ b/factory_json.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   # Compatibility test
   spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "ciderizer"
+  spec.add_development_dependency 'geminabox'
 end

--- a/lib/factory_bot/attribute_assigner_with_hash_support.rb
+++ b/lib/factory_bot/attribute_assigner_with_hash_support.rb
@@ -1,4 +1,4 @@
-module FactoryGirl
+module FactoryBot
   module AttributeAssignerWithHashSupport
     def object
       @evaluator.instance = build_class_instance

--- a/lib/factory_bot/strategy/as_json.rb
+++ b/lib/factory_bot/strategy/as_json.rb
@@ -1,8 +1,8 @@
-module FactoryGirl
+module FactoryBot
   module Strategy
-    class JSON
+    class AsJSON
       def initialize
-        @strategy = FactoryGirl.strategy_by_name(:build).new
+        @strategy = FactoryBot.strategy_by_name(:build).new
       end
 
       def association(runner)
@@ -14,7 +14,7 @@ module FactoryGirl
         result = @strategy.result(evaluation)
         evaluation.notify(:before_json, result)
 
-        result.to_json
+        ::JSON.parse result.to_json
       end
     end
   end

--- a/lib/factory_bot/strategy/json.rb
+++ b/lib/factory_bot/strategy/json.rb
@@ -1,8 +1,8 @@
-module FactoryGirl
+module FactoryBot
   module Strategy
-    class AsJSON
+    class JSON
       def initialize
-        @strategy = FactoryGirl.strategy_by_name(:build).new
+        @strategy = FactoryBot.strategy_by_name(:build).new
       end
 
       def association(runner)
@@ -14,7 +14,7 @@ module FactoryGirl
         result = @strategy.result(evaluation)
         evaluation.notify(:before_json, result)
 
-        ::JSON.parse result.to_json
+        result.to_json
       end
     end
   end

--- a/lib/factory_json.rb
+++ b/lib/factory_json.rb
@@ -1,13 +1,13 @@
 require 'json'
-require "factory_girl"
+require "factory_bot"
 
 require "factory_json/version"
 
-require "factory_girl/strategy/json"
-require "factory_girl/strategy/as_json"
-require "factory_girl/attribute_assigner_with_hash_support"
+require "factory_bot/strategy/json"
+require "factory_bot/strategy/as_json"
+require "factory_bot/attribute_assigner_with_hash_support"
 
-FactoryGirl.register_strategy(:json, FactoryGirl::Strategy::JSON)
-FactoryGirl.register_strategy(:as_json, FactoryGirl::Strategy::AsJSON)
+FactoryBot.register_strategy(:json, FactoryBot::Strategy::JSON)
+FactoryBot.register_strategy(:as_json, FactoryBot::Strategy::AsJSON)
 
-FactoryGirl::AttributeAssigner.prepend FactoryGirl::AttributeAssignerWithHashSupport
+FactoryBot::AttributeAssigner.prepend FactoryBot::AttributeAssignerWithHashSupport

--- a/lib/factory_json/version.rb
+++ b/lib/factory_json/version.rb
@@ -1,3 +1,3 @@
 module FactoryJson
-  VERSION = "1.0.0-pre1"
+  VERSION = "1.0.0"
 end

--- a/lib/factory_json/version.rb
+++ b/lib/factory_json/version.rb
@@ -1,3 +1,3 @@
 module FactoryJson
-  VERSION = "0.1.1"
+  VERSION = "1.0.0-pre1"
 end

--- a/spec/factory_bot/strategy/as_json_spec.rb
+++ b/spec/factory_bot/strategy/as_json_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FactoryGirl::Strategy::AsJSON do
+describe FactoryBot::Strategy::AsJSON do
   it_should_behave_like "strategy with association support", :build
   it_should_behave_like "json strategy with callbacks", {}, :after_build, :before_json
   it_should_behave_like "strategy with strategy: :build", :build

--- a/spec/factory_bot/strategy/as_json_spec.rb
+++ b/spec/factory_bot/strategy/as_json_spec.rb
@@ -23,7 +23,7 @@ describe FactoryBot::Strategy::AsJSON do
     it "does not run the to_create block" do
       expect do
         subject.result(evaluation)
-      end.to_not raise_error
+      end.not_to raise_error
     end
   end
 
@@ -45,7 +45,7 @@ describe FactoryBot::Strategy::AsJSON do
     it "does not run the to_create block" do
       expect do
         subject.result(evaluation)
-      end.to_not raise_error
+      end.not_to raise_error
     end
   end
 end

--- a/spec/factory_bot/strategy/json_spec.rb
+++ b/spec/factory_bot/strategy/json_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FactoryGirl::Strategy::JSON do
+describe FactoryBot::Strategy::JSON do
   it_should_behave_like "strategy with association support", :build
   it_should_behave_like "json strategy with callbacks", "{}", :after_build, :before_json
   it_should_behave_like "strategy with strategy: :build", :build

--- a/spec/factory_bot/strategy/json_spec.rb
+++ b/spec/factory_bot/strategy/json_spec.rb
@@ -17,7 +17,7 @@ describe FactoryBot::Strategy::JSON do
     it "does not run the to_create block" do
       expect do
         subject.result(evaluation)
-      end.to_not raise_error
+      end.not_to raise_error
     end
   end
 
@@ -33,7 +33,7 @@ describe FactoryBot::Strategy::JSON do
     it "does not run the to_create block" do
       expect do
         subject.result(evaluation)
-      end.to_not raise_error
+      end.not_to raise_error
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,6 @@ require "support/shared_examples/strategy"
 
 RSpec.configure do |config|
   config.mock_framework = :mocha
-  config.include DeclarationMatchers
 
   config.after do
     Timecop.return

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,10 +9,10 @@ require 'mocha/api'
 require 'bourne'
 require 'timecop'
 
-require 'factory_girl'
+require 'factory_bot'
 require 'factory_json'
 
-source_path = Gem::Specification.find_by_name('factory_girl').gem_dir
+source_path = Gem::Specification.find_by_name('factory_bot').gem_dir
 
 files = File.join(source_path, 'spec', 'support', 'macros', '**', '*.rb')
 Dir[files].each { |f| require File.expand_path(f) }
@@ -28,6 +28,6 @@ RSpec.configure do |config|
 
   config.after do
     Timecop.return
-    FactoryGirl.reload
+    FactoryBot.reload
   end
 end

--- a/spec/support/shared_examples/strategy.rb
+++ b/spec/support/shared_examples/strategy.rb
@@ -1,14 +1,14 @@
 shared_examples_for "strategy without association support" do
   let(:factory)   { stub("associate_factory") }
-  let(:attribute) { FactoryGirl::Attribute::Association.new(:user, :user, {}) }
+  let(:attribute) { FactoryBot::Attribute::Association.new(:user, :user, {}) }
 
   def association_named(name, overrides)
-    runner = FactoryGirl::FactoryRunner.new(name, :build, [overrides])
+    runner = FactoryBot::FactoryRunner.new(name, :build, [overrides])
     subject.association(runner)
   end
 
   before do
-    FactoryGirl.stubs(factory_by_name: factory)
+    FactoryBot.stubs(factory_by_name: factory)
     factory.stubs(:compile)
     factory.stubs(:run)
   end
@@ -18,53 +18,53 @@ shared_examples_for "strategy without association support" do
   end
 end
 
-shared_examples_for "strategy with association support" do |factory_girl_strategy_name|
+shared_examples_for "strategy with association support" do |factory_bot_strategy_name|
   let(:factory) { stub("associate_factory") }
 
   def association_named(name, strategy, overrides)
-    runner = FactoryGirl::FactoryRunner.new(name, strategy, [overrides])
+    runner = FactoryBot::FactoryRunner.new(name, strategy, [overrides])
     subject.association(runner)
   end
 
   before do
-    FactoryGirl.stubs(factory_by_name: factory)
+    FactoryBot.stubs(factory_by_name: factory)
     factory.stubs(:compile)
     factory.stubs(:run)
   end
 
   it "runs the factory with the correct overrides" do
-    association_named(:author, factory_girl_strategy_name, great: "value")
-    expect(factory).to have_received(:run).with(factory_girl_strategy_name, great: "value")
+    association_named(:author, factory_bot_strategy_name, great: "value")
+    expect(factory).to have_received(:run).with(factory_bot_strategy_name, great: "value")
   end
 
   it "finds the factory with the correct factory name" do
-    association_named(:author, factory_girl_strategy_name, great: "value")
-    expect(FactoryGirl).to have_received(:factory_by_name).with(:author)
+    association_named(:author, factory_bot_strategy_name, great: "value")
+    expect(FactoryBot).to have_received(:factory_by_name).with(:author)
   end
 end
 
-shared_examples_for "strategy with strategy: :build" do |factory_girl_strategy_name|
+shared_examples_for "strategy with strategy: :build" do |factory_bot_strategy_name|
   let(:factory) { stub("associate_factory") }
 
   def association_named(name, overrides)
-    runner = FactoryGirl::FactoryRunner.new(name, overrides[:strategy], [overrides.except(:strategy)])
+    runner = FactoryBot::FactoryRunner.new(name, overrides[:strategy], [overrides.except(:strategy)])
     subject.association(runner)
   end
 
   before do
-    FactoryGirl.stubs(factory_by_name: factory)
+    FactoryBot.stubs(factory_by_name: factory)
     factory.stubs(:compile)
     factory.stubs(:run)
   end
 
   it "runs the factory with the correct overrides" do
     association_named(:author, strategy: :build, great: "value")
-    expect(factory).to have_received(:run).with(factory_girl_strategy_name, great: "value")
+    expect(factory).to have_received(:run).with(factory_bot_strategy_name, great: "value")
   end
 
   it "finds the factory with the correct factory name" do
     association_named(:author, strategy: :build, great: "value")
-    expect(FactoryGirl).to have_received(:factory_by_name).with(:author)
+    expect(FactoryBot).to have_received(:factory_by_name).with(:author)
   end
 end
 


### PR DESCRIPTION
using the internal registry because `ciderizer` has a (by now?) private dependency `ruby-static-code-analysis`